### PR TITLE
Add Filter operator to Select, Update, Delete query plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ version = "0.1.0"
 name = "query_parser"
 version = "0.1.0"
 dependencies = [
+ "log",
  "postgres-parser",
  "query_ast",
  "query_response",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ version = "0.1.0"
 dependencies = [
  "bigdecimal",
  "data_manipulation_query_result",
+ "log",
  "query_ast",
  "regex",
  "rstest",

--- a/node_engine/src/lib.rs
+++ b/node_engine/src/lib.rs
@@ -115,7 +115,7 @@ pub fn start(database: Database) {
                     let (conn_id, secret_key) = match conn_supervisor.alloc() {
                         Ok((c, s)) => (c, s),
                         Err(()) => {
-                            eprintln!("Cannot allocate connection and its secret key");
+                            log::error!("Cannot allocate connection and its secret key");
                             return;
                         }
                     };

--- a/node_engine/src/query_engine/mod.rs
+++ b/node_engine/src/query_engine/mod.rs
@@ -291,9 +291,23 @@ impl QueryEngine {
                                                 }
                                             }
                                             UntypedQuery::Delete(delete) => {
+
+                                                log::debug!("DELETE UNTYPED FILTER - {:?}", delete.filter);
+                                                let typed_filter = delete
+                                                    .filter
+                                                    .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                                log::debug!("DELETE TYPED FILTER - {:?}", typed_filter);
+                                                let type_checked_filter = typed_filter
+                                                    .map(|value| self.type_checker.check_dynamic(value));
+                                                log::debug!("DELETE TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                                let type_coerced_filter = type_checked_filter
+                                                    .map(|value| self.type_coercion.coerce_dynamic(value));
+                                                log::debug!("DELETE TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                                 let query_result = match query_planner
                                                     .plan(TypedQuery::Delete(TypedDeleteQuery {
                                                         full_table_name: delete.full_table_name,
+                                                        filter: type_coerced_filter
                                                     }))
                                                     .execute(param_values)
                                                     .map(|r| { let r: QueryEvent = r.into(); r })
@@ -343,9 +357,23 @@ impl QueryEngine {
                             },
                             Statement::Query(query) => match query_analyzer.analyze(query) {
                                 Ok(UntypedQuery::Delete(delete)) => {
+
+                                    log::debug!("DELETE UNTYPED FILTER - {:?}", delete.filter);
+                                    let typed_filter = delete
+                                        .filter
+                                        .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                    log::debug!("DELETE TYPED FILTER - {:?}", typed_filter);
+                                    let type_checked_filter = typed_filter
+                                        .map(|value| self.type_checker.check_dynamic(value));
+                                    log::debug!("DELETE TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                    let type_coerced_filter = type_checked_filter
+                                        .map(|value| self.type_coercion.coerce_dynamic(value));
+                                    log::debug!("DELETE TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                     let query_result = match query_planner
                                         .plan(TypedQuery::Delete(TypedDeleteQuery {
                                             full_table_name: delete.full_table_name,
+                                            filter: type_coerced_filter
                                         }))
                                         .execute(vec![])
                                         .map(|r| { let r: QueryEvent = r.into(); r })
@@ -1002,9 +1030,23 @@ impl QueryEngine {
                                 }
                             }
                             UntypedQuery::Delete(delete) => {
+
+                                log::debug!("DELETE UNTYPED FILTER - {:?}", delete.filter);
+                                let typed_filter = delete
+                                    .filter
+                                    .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                log::debug!("DELETE TYPED FILTER - {:?}", typed_filter);
+                                let type_checked_filter = typed_filter
+                                    .map(|value| self.type_checker.check_dynamic(value));
+                                log::debug!("DELETE TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                let type_coerced_filter = type_checked_filter
+                                    .map(|value| self.type_coercion.coerce_dynamic(value));
+                                log::debug!("DELETE TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                 let query_result = match query_planner
                                     .plan(TypedQuery::Delete(TypedDeleteQuery {
                                         full_table_name: delete.full_table_name,
+                                        filter: type_coerced_filter
                                     }))
                                     .execute(vec![])
                                     .map(|r| { let r: QueryEvent = r.into(); r })

--- a/node_engine/src/query_engine/mod.rs
+++ b/node_engine/src/query_engine/mod.rs
@@ -189,10 +189,24 @@ impl QueryEngine {
                                                     })
                                                     .collect::<Vec<Option<DynamicTypedTree>>>();
                                                 log::debug!("UPDATE TYPE COERCED VALUES - {:?}", type_coerced);
+
+                                                log::debug!("UPDATE UNTYPED FILTER - {:?}", update.filter);
+                                                let typed_filter = update
+                                                    .filter
+                                                    .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                                log::debug!("UPDATE TYPED FILTER - {:?}", typed_filter);
+                                                let type_checked_filter = typed_filter
+                                                    .map(|value| self.type_checker.check_dynamic(value));
+                                                log::debug!("UPDATE TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                                let type_coerced_filter = type_checked_filter
+                                                    .map(|value| self.type_coercion.coerce_dynamic(value));
+                                                log::debug!("UPDATE TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                                 let query_result = match query_planner
                                                     .plan(TypedQuery::Update(TypedUpdateQuery {
                                                         full_table_name: update.full_table_name,
                                                         assignments: type_coerced,
+                                                        filter: type_coerced_filter
                                                     }))
                                                     .execute(param_values)
                                                     .map(|r| { let r: QueryEvent = r.into(); r })
@@ -222,11 +236,24 @@ impl QueryEngine {
                                                     .map(|value| self.type_coercion.coerce_dynamic(value))
                                                     .collect::<Vec<DynamicTypedTree>>();
                                                 log::debug!("SELECT TYPE COERCED VALUES - {:?}", type_coerced);
+
+                                                log::debug!("SELECT UNTYPED FILTER - {:?}", select.filter);
+                                                let typed_filter = select
+                                                    .filter
+                                                    .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                                log::debug!("SELECT TYPED FILTER - {:?}", typed_filter);
+                                                let type_checked_filter = typed_filter
+                                                    .map(|value| self.type_checker.check_dynamic(value));
+                                                log::debug!("SELECT TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                                let type_coerced_filter = type_checked_filter
+                                                    .map(|value| self.type_coercion.coerce_dynamic(value));
+                                                log::debug!("SELECT TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                                 let query_result = query_planner
                                                     .plan(TypedQuery::Select(TypedSelectQuery {
                                                         projection_items: type_coerced,
                                                         full_table_name: select.full_table_name,
-                                                        filter: None
+                                                        filter: type_coerced_filter
                                                     }))
                                                     .execute(param_values)
                                                     .map_err(|e| { let e: QueryError = e.into(); e })
@@ -347,10 +374,24 @@ impl QueryEngine {
                                         .map(|value| value.map(|value| self.type_coercion.coerce_dynamic(value)))
                                         .collect::<Vec<Option<DynamicTypedTree>>>();
                                     log::debug!("UPDATE TYPE COERCED VALUES - {:?}", type_coerced);
+
+                                    log::debug!("UPDATE UNTYPED FILTER - {:?}", update.filter);
+                                    let typed_filter = update
+                                        .filter
+                                        .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                    log::debug!("UPDATE TYPED FILTER - {:?}", typed_filter);
+                                    let type_checked_filter = typed_filter
+                                        .map(|value| self.type_checker.check_dynamic(value));
+                                    log::debug!("UPDATE TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                    let type_coerced_filter = type_checked_filter
+                                        .map(|value| self.type_coercion.coerce_dynamic(value));
+                                    log::debug!("UPDATE TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                     let query_result = match query_planner
                                         .plan(TypedQuery::Update(TypedUpdateQuery {
                                             full_table_name: update.full_table_name,
                                             assignments: type_coerced,
+                                            filter: type_coerced_filter
                                         }))
                                         .execute(vec![])
                                         .map(|r| { let r: QueryEvent = r.into(); r })
@@ -861,10 +902,24 @@ impl QueryEngine {
                                     .map(|value| value.map(|value| self.type_coercion.coerce_dynamic(value)))
                                     .collect::<Vec<Option<DynamicTypedTree>>>();
                                 log::debug!("UPDATE TYPE COERCED VALUES - {:?}", type_coerced);
+
+                                log::debug!("UPDATE UNTYPED FILTER - {:?}", update.filter);
+                                let typed_filter = update
+                                    .filter
+                                    .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                log::debug!("UPDATE TYPED FILTER - {:?}", typed_filter);
+                                let type_checked_filter = typed_filter
+                                    .map(|value| self.type_checker.check_dynamic(value));
+                                log::debug!("UPDATE TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                let type_coerced_filter = type_checked_filter
+                                    .map(|value| self.type_coercion.coerce_dynamic(value));
+                                log::debug!("UPDATE TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                 let query_result = match query_planner
                                     .plan(TypedQuery::Update(TypedUpdateQuery {
                                         full_table_name: update.full_table_name,
                                         assignments: type_coerced,
+                                        filter: type_coerced_filter
                                     }))
                                     .execute(portal.param_values())
                                     .map(|r| { let r: QueryEvent = r.into(); r })
@@ -894,11 +949,24 @@ impl QueryEngine {
                                     .map(|value| self.type_coercion.coerce_dynamic(value))
                                     .collect::<Vec<DynamicTypedTree>>();
                                 log::debug!("SELECT TYPE COERCED VALUES - {:?}", type_coerced);
+
+                                log::debug!("SELECT UNTYPED FILTER - {:?}", select.filter);
+                                let typed_filter = select
+                                    .filter
+                                    .map(|value| self.type_inference.infer_dynamic(value, &[]));
+                                log::debug!("SELECT TYPED FILTER - {:?}", typed_filter);
+                                let type_checked_filter = typed_filter
+                                    .map(|value| self.type_checker.check_dynamic(value));
+                                log::debug!("SELECT TYPE CHECKED FILTER - {:?}", type_checked_filter);
+                                let type_coerced_filter = type_checked_filter
+                                    .map(|value| self.type_coercion.coerce_dynamic(value));
+                                log::debug!("SELECT TYPE COERCED FILTER - {:?}", type_coerced_filter);
+
                                 let query_result = query_planner
                                     .plan(TypedQuery::Select(TypedSelectQuery {
                                         projection_items: type_coerced,
                                         full_table_name: select.full_table_name,
-                                        filter: None
+                                        filter: type_coerced_filter
                                     }))
                                     .execute(vec![])
                                     .map_err(|e| { let e: QueryError = e.into(); e })

--- a/node_engine/src/query_engine/tests/mod.rs
+++ b/node_engine/src/query_engine/tests/mod.rs
@@ -30,6 +30,8 @@ mod extended_query_flow;
 #[cfg(test)]
 mod insert;
 #[cfg(test)]
+mod predicate;
+#[cfg(test)]
 mod schema;
 #[cfg(test)]
 mod select;

--- a/node_engine/src/query_engine/tests/predicate.rs
+++ b/node_engine/src/query_engine/tests/predicate.rs
@@ -112,3 +112,49 @@ fn update_value_by_predicate_on_single_field(database_with_schema: (InMemory, Re
         Ok(QueryEvent::RecordsSelected(1)),
     ]);
 }
+
+#[rstest::rstest]
+fn delete_value_by_predicate_on_single_field(database_with_schema: (InMemory, ResultCollector)) {
+    let (mut engine, collector) = database_with_schema;
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "insert into schema_name.table_name values (1, 2, 3), (4, 5, 6);".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(2)));
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "delete from schema_name.table_name where col1 = 1;".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsDeleted(1)));
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "select * from schema_name.table_name".to_owned(),
+        })
+        .expect("query executed");
+
+    collector.assert_receive_many(vec![
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PgType::SmallInt),
+            ColumnMetadata::new("col2", PgType::SmallInt),
+            ColumnMetadata::new("col3", PgType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "4".to_owned(),
+            "5".to_owned(),
+            "6".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(1)),
+    ]);
+}

--- a/node_engine/src/query_engine/tests/predicate.rs
+++ b/node_engine/src/query_engine/tests/predicate.rs
@@ -66,21 +66,21 @@ fn update_value_by_predicate_on_single_field(database_with_schema: (InMemory, Re
 
     engine
         .execute(CommandMessage::Query {
-            sql: "insert into schema_name.table_name values (1, 2, 3), (4, 5, 6);".to_owned(),
+            sql: "insert into schema_name.table_name values (1, 2, 3), (4, 5, 6), (7, 8, 9);".to_owned(),
         })
         .expect("query executed");
-    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(2)));
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute(CommandMessage::Query {
-            sql: "update schema_name.table_name set col1 = 7 where col1 = 1;".to_owned(),
+            sql: "update schema_name.table_name set col1 = 7 where col1 = 4;".to_owned(),
         })
         .expect("query executed");
     collector.assert_receive_single(Ok(QueryEvent::RecordsUpdated(1)));
 
     engine
         .execute(CommandMessage::Query {
-            sql: "select * from schema_name.table_name where col1 = 1".to_owned(),
+            sql: "select * from schema_name.table_name where col1 = 4".to_owned(),
         })
         .expect("query executed");
 
@@ -106,10 +106,15 @@ fn update_value_by_predicate_on_single_field(database_with_schema: (InMemory, Re
         ])),
         Ok(QueryEvent::DataRow(vec![
             "7".to_owned(),
-            "2".to_owned(),
-            "3".to_owned(),
+            "5".to_owned(),
+            "6".to_owned(),
         ])),
-        Ok(QueryEvent::RecordsSelected(1)),
+        Ok(QueryEvent::DataRow(vec![
+            "7".to_owned(),
+            "8".to_owned(),
+            "9".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(2)),
     ]);
 }
 
@@ -126,14 +131,14 @@ fn delete_value_by_predicate_on_single_field(database_with_schema: (InMemory, Re
 
     engine
         .execute(CommandMessage::Query {
-            sql: "insert into schema_name.table_name values (1, 2, 3), (4, 5, 6);".to_owned(),
+            sql: "insert into schema_name.table_name values (1, 2, 3), (4, 5, 6), (7, 8, 9);".to_owned(),
         })
         .expect("query executed");
-    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(2)));
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute(CommandMessage::Query {
-            sql: "delete from schema_name.table_name where col1 = 1;".to_owned(),
+            sql: "delete from schema_name.table_name where col2 = 5;".to_owned(),
         })
         .expect("query executed");
     collector.assert_receive_single(Ok(QueryEvent::RecordsDeleted(1)));
@@ -151,10 +156,15 @@ fn delete_value_by_predicate_on_single_field(database_with_schema: (InMemory, Re
             ColumnMetadata::new("col3", PgType::SmallInt),
         ])),
         Ok(QueryEvent::DataRow(vec![
-            "4".to_owned(),
-            "5".to_owned(),
-            "6".to_owned(),
+            "1".to_owned(),
+            "2".to_owned(),
+            "3".to_owned(),
         ])),
-        Ok(QueryEvent::RecordsSelected(1)),
+        Ok(QueryEvent::DataRow(vec![
+            "7".to_owned(),
+            "8".to_owned(),
+            "9".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(2)),
     ]);
 }

--- a/node_engine/src/query_engine/tests/predicate.rs
+++ b/node_engine/src/query_engine/tests/predicate.rs
@@ -1,0 +1,54 @@
+// Copyright 2020 - 2021 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[rstest::rstest]
+fn select_value_by_predicate_on_single_field(database_with_schema: (InMemory, ResultCollector)) {
+    let (mut engine, collector) = database_with_schema;
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "insert into schema_name.table_name values (1, 2, 3), (4, 5, 6);".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(2)));
+
+    engine
+        .execute(CommandMessage::Query {
+            sql: "select * from schema_name.table_name where col1 = 1".to_owned(),
+        })
+        .expect("query executed");
+
+    collector.assert_receive_many(vec![
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PgType::SmallInt),
+            ColumnMetadata::new("col2", PgType::SmallInt),
+            ColumnMetadata::new("col3", PgType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "1".to_owned(),
+            "2".to_owned(),
+            "3".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(1)),
+    ]);
+}

--- a/postgres/query_parser/Cargo.toml
+++ b/postgres/query_parser/Cargo.toml
@@ -10,6 +10,7 @@ query_ast = { path = "../query_ast" }
 query_response = { path = "../query_response" }
 
 postgres-parser = "0.2"
+log = "0.4.14"
 
 [dev-dependencies]
 rstest = "0.7.0"

--- a/postgres/query_parser/src/lib.rs
+++ b/postgres/query_parser/src/lib.rs
@@ -79,7 +79,7 @@ impl QueryParser {
                         sys::ObjectType::OBJECT_SCHEMA => {
                             let mut names = vec![];
                             for object in objects.unwrap() {
-                                println!("OBJECT - {:?}", object);
+                                log::trace!("OBJECT - {:?}", object);
                                 match object {
                                     Node::Value(nodes::Value { string: Some(name), .. }) => names.push(name),
                                     _ => unimplemented!(),
@@ -94,7 +94,7 @@ impl QueryParser {
                         sys::ObjectType::OBJECT_TABLE => {
                             let mut names = vec![];
                             for object in objects.unwrap() {
-                                println!("OBJECT - {:?}", object);
+                                log::trace!("OBJECT - {:?}", object);
                                 match object {
                                     Node::List(mut values) => {
                                         if values.len() == 1 {
@@ -157,7 +157,7 @@ impl QueryParser {
                 }))) => {
                     let mut column_names = vec![];
                     for index_param in index_params.unwrap() {
-                        println!("INDEX PARAM - {:?}", index_param);
+                        log::trace!("INDEX PARAM - {:?}", index_param);
                         match index_param {
                             Node::IndexElem(nodes::IndexElem { name: Some(name), .. }) => {
                                 column_names.push(name.to_lowercase())
@@ -247,7 +247,7 @@ impl QueryParser {
                 let table_name = relation.relname.unwrap();
                 let mut columns = vec![];
                 for col in cols.unwrap_or_else(Vec::new) {
-                    println!("COL {:?}", col);
+                    log::trace!("COL {:?}", col);
                     match col {
                         Node::ResTarget(nodes::ResTarget {
                             name: Some(col_name), ..
@@ -257,7 +257,7 @@ impl QueryParser {
                         _ => unimplemented!(),
                     }
                 }
-                println!("SELECT STMT - {:?}", select_statement);
+                log::trace!("SELECT STMT - {:?}", select_statement);
                 let mut values = vec![];
                 if let Some(stmt) = select_statement {
                     if let Node::SelectStmt(nodes::SelectStmt {
@@ -306,7 +306,7 @@ impl QueryParser {
                 larg: None,
                 rarg: None,
             }) => {
-                println!("TARGET LIST {:?}", target_list);
+                log::trace!("TARGET LIST {:?}", target_list);
                 let mut select_items = vec![];
                 for target in target_list.unwrap() {
                     match target {
@@ -357,7 +357,7 @@ impl QueryParser {
                 let table_name = relation.relname.unwrap();
                 let mut assignments = vec![];
                 for target in target_list.unwrap() {
-                    println!("{:?}", target);
+                    log::trace!("{:?}", target);
                     match target {
                         Node::ResTarget(nodes::ResTarget { name, val, .. }) => assignments.push(Assignment {
                             column: name.unwrap().to_lowercase(),
@@ -406,7 +406,7 @@ impl QueryParser {
     }
 
     fn process_type(&self, type_name: nodes::TypeName) -> DataType {
-        println!("TYPE NAME {:#?}", type_name);
+        log::trace!("TYPE NAME {:#?}", type_name);
         let name = type_name.names.unwrap();
         let mode = type_name.typmods;
         match &name[1] {
@@ -441,7 +441,7 @@ impl QueryParser {
     }
 
     fn parse_expr(&self, node: Node) -> Expr {
-        println!("NODE {:?}", node);
+        log::trace!("NODE {:?}", node);
         match node {
             Node::BoolExpr(nodes::BoolExpr { boolop: bool_op, args }) => {
                 let op = match bool_op {

--- a/postgres/query_parser/src/tests/mod.rs
+++ b/postgres/query_parser/src/tests/mod.rs
@@ -23,6 +23,8 @@ mod index;
 #[cfg(test)]
 mod insert;
 #[cfg(test)]
+mod predicate;
+#[cfg(test)]
 mod schema;
 #[cfg(test)]
 mod select;

--- a/postgres/query_parser/src/tests/predicate.rs
+++ b/postgres/query_parser/src/tests/predicate.rs
@@ -1,0 +1,74 @@
+// Copyright 2020 - 2021 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[test]
+fn select() {
+    let statements = QUERY_PARSER.parse("select * from schema_name.table_name where col1 = 1;");
+
+    assert_eq!(
+        statements,
+        Ok(vec![Statement::Query(Query::Select(SelectStatement {
+            select_items: vec![SelectItem::Wildcard],
+            schema_name: "schema_name".to_owned(),
+            table_name: "table_name".to_owned(),
+            where_clause: Some(Expr::BinaryOp {
+                left: Box::new(Expr::Column("col1".to_owned())),
+                op: BinaryOperator::Eq,
+                right: Box::new(Expr::Value(Value::Int(1)))
+            }),
+        }))])
+    );
+}
+
+#[test]
+fn update() {
+    let statements = QUERY_PARSER.parse("update schema_name.table_name set col1 = 123 where col2 = 2;");
+
+    assert_eq!(
+        statements,
+        Ok(vec![Statement::Query(Query::Update(UpdateStatement {
+            schema_name: "schema_name".to_owned(),
+            table_name: "table_name".to_owned(),
+            assignments: vec![Assignment {
+                column: "col1".to_owned(),
+                value: Expr::Value(Value::Int(123))
+            }],
+            where_clause: Some(Expr::BinaryOp {
+                left: Box::new(Expr::Column("col2".to_owned())),
+                op: BinaryOperator::Eq,
+                right: Box::new(Expr::Value(Value::Int(2)))
+            }),
+        }))])
+    );
+}
+
+#[test]
+fn delete() {
+    let statements = QUERY_PARSER.parse("delete from schema_name.table_name where col1 = 1;");
+
+    assert_eq!(
+        statements,
+        Ok(vec![Statement::Query(Query::Delete(DeleteStatement {
+            schema_name: "schema_name".to_owned(),
+            table_name: "table_name".to_owned(),
+            where_clause: Some(Expr::BinaryOp {
+                left: Box::new(Expr::Column("col1".to_owned())),
+                op: BinaryOperator::Eq,
+                right: Box::new(Expr::Value(Value::Int(1)))
+            }),
+        }))])
+    );
+}

--- a/sql_engine/catalog/src/lib.rs
+++ b/sql_engine/catalog/src/lib.rs
@@ -235,7 +235,7 @@ impl<'c> CatalogHandler<'c> {
                                 && value[1] == full_table_name.schema()
                                 && value[2] == full_table_name.table()
                         });
-                        println!("DEBUG {:?}", table_id);
+                        log::trace!("DEBUG {:?}", table_id);
                         match table_id {
                             Some(_table_id) => {
                                 if if_not_exists {

--- a/sql_engine/data_manipulation/operators/Cargo.toml
+++ b/sql_engine/data_manipulation/operators/Cargo.toml
@@ -13,6 +13,7 @@ scalar = { path = "../../scalar" }
 
 bigdecimal = { version = "0.2.0", features = ["string-only"] }
 regex = "1.4.3"
+log = "0.4.14"
 
 [dev-dependencies]
 rstest = "0.7.0"

--- a/sql_engine/data_manipulation/operators/src/lib.rs
+++ b/sql_engine/data_manipulation/operators/src/lib.rs
@@ -17,6 +17,7 @@ use data_manipulation_query_result::QueryExecutionError;
 use query_ast::{BinaryOperator, UnaryOperator};
 use regex::Regex;
 use scalar::ScalarValue;
+use std::fmt::Debug;
 use std::{
     fmt::{self, Display, Formatter},
     str::FromStr,
@@ -86,7 +87,8 @@ pub enum Comparison {
 }
 
 impl Comparison {
-    fn eval<E: PartialEq + PartialOrd>(&self, left_value: E, right_value: E) -> bool {
+    fn eval<E: PartialEq + PartialOrd + Debug>(&self, left_value: E, right_value: E) -> bool {
+        log::debug!("Comparison {:?} {:?} {:?}", left_value, self, right_value);
         match self {
             Comparison::NotEq => left_value != right_value,
             Comparison::Eq => left_value == right_value,

--- a/sql_engine/data_manipulation/operators/src/lib.rs
+++ b/sql_engine/data_manipulation/operators/src/lib.rs
@@ -17,9 +17,8 @@ use data_manipulation_query_result::QueryExecutionError;
 use query_ast::{BinaryOperator, UnaryOperator};
 use regex::Regex;
 use scalar::ScalarValue;
-use std::fmt::Debug;
 use std::{
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     str::FromStr,
 };
 use types::{Bool, SqlTypeFamily};

--- a/sql_engine/data_manipulation/typed_queries/src/lib.rs
+++ b/sql_engine/data_manipulation/typed_queries/src/lib.rs
@@ -30,6 +30,7 @@ pub struct TypedDeleteQuery {
 pub struct TypedUpdateQuery {
     pub full_table_name: FullTableName,
     pub assignments: Vec<Option<DynamicTypedTree>>,
+    pub filter: Option<DynamicTypedTree>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/sql_engine/data_manipulation/typed_queries/src/lib.rs
+++ b/sql_engine/data_manipulation/typed_queries/src/lib.rs
@@ -44,4 +44,5 @@ pub enum TypedQuery {
 pub struct TypedSelectQuery {
     pub full_table_name: FullTableName,
     pub projection_items: Vec<DynamicTypedTree>,
+    pub filter: Option<DynamicTypedTree>,
 }

--- a/sql_engine/data_manipulation/typed_queries/src/lib.rs
+++ b/sql_engine/data_manipulation/typed_queries/src/lib.rs
@@ -24,6 +24,7 @@ pub struct TypedInsertQuery {
 #[derive(Debug, PartialEq)]
 pub struct TypedDeleteQuery {
     pub full_table_name: FullTableName,
+    pub filter: Option<DynamicTypedTree>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/sql_engine/data_manipulation/untyped_queries/src/lib.rs
+++ b/sql_engine/data_manipulation/untyped_queries/src/lib.rs
@@ -25,6 +25,7 @@ pub struct UntypedInsertQuery {
 pub struct UntypedUpdateQuery {
     pub full_table_name: FullTableName,
     pub assignments: Vec<Option<DynamicUntypedTree>>,
+    pub filter: Option<DynamicUntypedTree>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/sql_engine/data_manipulation/untyped_queries/src/lib.rs
+++ b/sql_engine/data_manipulation/untyped_queries/src/lib.rs
@@ -38,6 +38,7 @@ pub struct UntypedSelectQuery {
 #[derive(Debug, PartialEq, Clone)]
 pub struct UntypedDeleteQuery {
     pub full_table_name: FullTableName,
+    pub filter: Option<DynamicUntypedTree>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/sql_engine/data_manipulation/untyped_queries/src/lib.rs
+++ b/sql_engine/data_manipulation/untyped_queries/src/lib.rs
@@ -31,6 +31,7 @@ pub struct UntypedUpdateQuery {
 pub struct UntypedSelectQuery {
     pub full_table_name: FullTableName,
     pub projection_items: Vec<DynamicUntypedTree>,
+    pub filter: Option<DynamicUntypedTree>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/sql_engine/entities/types/src/lib.rs
+++ b/sql_engine/entities/types/src/lib.rs
@@ -25,7 +25,7 @@ pub struct IncomparableSqlTypeFamilies {
     right: SqlTypeFamily,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum SqlTypeFamily {
     Bool,
     String,

--- a/sql_engine/query_analyzer/src/lib.rs
+++ b/sql_engine/query_analyzer/src/lib.rs
@@ -154,7 +154,7 @@ impl<'a> QueryAnalyzer<'a> {
                 select_items,
                 schema_name,
                 table_name,
-                where_clause: _where_clause,
+                where_clause,
             }) => {
                 let full_table_name = FullTableName::from((&schema_name, &table_name));
                 match self.catalog.table_definition(full_table_name.clone()) {
@@ -179,9 +179,14 @@ impl<'a> QueryAnalyzer<'a> {
                                 }
                             }
                         }
+                        let filter = match where_clause {
+                            Some(expr) => Some(DynamicTreeBuilder::build_from(expr, &table_columns)?),
+                            None => None,
+                        };
                         Ok(UntypedQuery::Select(UntypedSelectQuery {
                             full_table_name,
                             projection_items,
+                            filter,
                         }))
                     }
                 }

--- a/sql_engine/query_analyzer/src/lib.rs
+++ b/sql_engine/query_analyzer/src/lib.rs
@@ -199,13 +199,23 @@ impl<'a> QueryAnalyzer<'a> {
             Query::Delete(DeleteStatement {
                 schema_name,
                 table_name,
-                where_clause: _where_clause,
+                where_clause,
             }) => {
                 let full_table_name = FullTableName::from((&schema_name, &table_name));
                 match self.catalog.table_definition(full_table_name.clone()) {
                     None => Err(AnalysisError::schema_does_not_exist(full_table_name.schema())),
                     Some(None) => Err(AnalysisError::table_does_not_exist(full_table_name)),
-                    Some(Some(_table_info)) => Ok(UntypedQuery::Delete(UntypedDeleteQuery { full_table_name })),
+                    Some(Some(table_info)) => {
+                        let table_columns = table_info.columns();
+                        let filter = match where_clause {
+                            Some(expr) => Some(DynamicTreeBuilder::build_from(expr, &table_columns)?),
+                            None => None,
+                        };
+                        Ok(UntypedQuery::Delete(UntypedDeleteQuery {
+                            full_table_name,
+                            filter,
+                        }))
+                    }
                 }
             }
         }

--- a/sql_engine/query_analyzer/src/lib.rs
+++ b/sql_engine/query_analyzer/src/lib.rs
@@ -106,7 +106,7 @@ impl<'a> QueryAnalyzer<'a> {
                 schema_name,
                 table_name,
                 assignments: stmt_assignments,
-                where_clause: _where_clause,
+                where_clause,
             }) => {
                 let full_table_name = FullTableName::from((&schema_name, &table_name));
                 match self.catalog.table_definition(full_table_name.clone()) {
@@ -143,9 +143,14 @@ impl<'a> QueryAnalyzer<'a> {
                                 }
                             }
                         }
+                        let filter = match where_clause {
+                            Some(expr) => Some(DynamicTreeBuilder::build_from(expr, &table_columns)?),
+                            None => None,
+                        };
                         Ok(UntypedQuery::Update(UntypedUpdateQuery {
                             full_table_name,
                             assignments,
+                            filter,
                         }))
                     }
                 }

--- a/sql_engine/query_analyzer/src/tests/delete.rs
+++ b/sql_engine/query_analyzer/src/tests/delete.rs
@@ -67,6 +67,7 @@ fn delete_all_from_table() -> TransactionResult<()> {
             analyzer.analyze(delete_statement(SCHEMA, TABLE)),
             Ok(UntypedQuery::Delete(UntypedDeleteQuery {
                 full_table_name: FullTableName::from((&SCHEMA, &TABLE)),
+                filter: None
             }))
         );
         Ok(())

--- a/sql_engine/query_analyzer/src/tests/selects/expressions.rs
+++ b/sql_engine/query_analyzer/src/tests/selects/expressions.rs
@@ -35,6 +35,7 @@ fn select_all_columns_from_table() -> TransactionResult<()> {
                     index: 0,
                     sql_type: SqlType::integer()
                 })],
+                filter: None
             }))
         );
         Ok(())
@@ -64,6 +65,7 @@ fn select_specified_column_from_table() -> TransactionResult<()> {
                     index: 0,
                     sql_type: SqlType::integer()
                 })],
+                filter: None
             }))
         );
         Ok(())
@@ -113,6 +115,7 @@ fn select_from_table_with_constant() -> TransactionResult<()> {
                 projection_items: vec![DynamicUntypedTree::Item(DynamicUntypedItem::Const(
                     UntypedValue::Number(BigDecimal::from(1))
                 ))],
+                filter: None
             }))
         );
         Ok(())
@@ -138,6 +141,7 @@ fn select_parameters_from_a_table() -> TransactionResult<()> {
             Ok(UntypedQuery::Select(UntypedSelectQuery {
                 full_table_name: FullTableName::from((&SCHEMA, &TABLE)),
                 projection_items: vec![DynamicUntypedTree::Item(DynamicUntypedItem::Param(0))],
+                filter: None
             }))
         );
         Ok(())
@@ -189,6 +193,7 @@ mod multiple_values {
                             UntypedValue::Number(BigDecimal::from(1))
                         )))
                     }],
+                    filter: None
                 }))
             );
             Ok(())
@@ -222,6 +227,7 @@ mod multiple_values {
                             UntypedValue::String("str".to_owned())
                         )))
                     }],
+                    filter: None
                 }))
             );
             Ok(())
@@ -255,6 +261,7 @@ mod multiple_values {
                             UntypedValue::Number(BigDecimal::from(1))
                         )))
                     }],
+                    filter: None
                 }))
             );
             Ok(())
@@ -288,6 +295,7 @@ mod multiple_values {
                             Bool(true)
                         )))),
                     }],
+                    filter: None
                 }))
             );
             Ok(())
@@ -321,6 +329,7 @@ mod multiple_values {
                             UntypedValue::Number(BigDecimal::from(1))
                         )))
                     }],
+                    filter: None
                 }))
             );
             Ok(())
@@ -354,6 +363,7 @@ mod multiple_values {
                             UntypedValue::String("str".to_owned())
                         )))
                     }],
+                    filter: None
                 }))
             );
             Ok(())

--- a/sql_engine/query_analyzer/src/tests/updates/expressions.rs
+++ b/sql_engine/query_analyzer/src/tests/updates/expressions.rs
@@ -32,7 +32,8 @@ fn update_number() -> TransactionResult<()> {
                 full_table_name: FullTableName::from((&SCHEMA, &TABLE)),
                 assignments: vec![Some(DynamicUntypedTree::Item(DynamicUntypedItem::Const(
                     UntypedValue::Number(BigDecimal::from(1))
-                )))]
+                )))],
+                filter: None
             }))
         );
         Ok(())
@@ -55,7 +56,8 @@ fn update_string() -> TransactionResult<()> {
                 full_table_name: FullTableName::from((&SCHEMA, &TABLE)),
                 assignments: vec![Some(DynamicUntypedTree::Item(DynamicUntypedItem::Const(
                     UntypedValue::String("str".to_owned())
-                )))]
+                )))],
+                filter: None
             }))
         );
         Ok(())
@@ -79,6 +81,7 @@ fn update_boolean() -> TransactionResult<()> {
                 assignments: vec![Some(DynamicUntypedTree::Item(DynamicUntypedItem::Const(
                     UntypedValue::Bool(Bool(true))
                 )))],
+                filter: None
             }))
         );
         Ok(())
@@ -102,6 +105,7 @@ fn update_null() -> TransactionResult<()> {
                 assignments: vec![Some(DynamicUntypedTree::Item(DynamicUntypedItem::Const(
                     UntypedValue::Null
                 )))],
+                filter: None
             }))
         );
         Ok(())
@@ -138,6 +142,7 @@ fn update_with_column_value() -> TransactionResult<()> {
                     })),
                     None
                 ],
+                filter: None
             }))
         );
         Ok(())
@@ -188,7 +193,8 @@ fn update_table_with_parameters() -> TransactionResult<()> {
             analyzer.analyze(update_stmt_with_parameters(SCHEMA, TABLE)),
             Ok(UntypedQuery::Update(UntypedUpdateQuery {
                 full_table_name: FullTableName::from((&SCHEMA, &TABLE)),
-                assignments: vec![None, Some(DynamicUntypedTree::Item(DynamicUntypedItem::Param(0)))]
+                assignments: vec![None, Some(DynamicUntypedTree::Item(DynamicUntypedItem::Param(0)))],
+                filter: None
             }))
         );
         Ok(())
@@ -243,6 +249,7 @@ mod multiple_values {
                             UntypedValue::Number(BigDecimal::from(1))
                         )))
                     })],
+                    filter: None
                 }))
             );
             Ok(())
@@ -276,6 +283,7 @@ mod multiple_values {
                             UntypedValue::String("str".to_owned())
                         )))
                     })],
+                    filter: None
                 }))
             );
             Ok(())
@@ -309,6 +317,7 @@ mod multiple_values {
                             UntypedValue::Number(BigDecimal::from(1))
                         )))
                     })],
+                    filter: None
                 }))
             );
             Ok(())
@@ -342,6 +351,7 @@ mod multiple_values {
                             Bool(true)
                         )))),
                     })],
+                    filter: None
                 }))
             );
             Ok(())
@@ -375,6 +385,7 @@ mod multiple_values {
                             UntypedValue::Number(BigDecimal::from(1))
                         )))
                     })],
+                    filter: None
                 }))
             );
             Ok(())
@@ -408,6 +419,7 @@ mod multiple_values {
                             UntypedValue::String("str".to_owned())
                         )))
                     })],
+                    filter: None
                 }))
             );
             Ok(())

--- a/sql_engine/query_planner/src/lib.rs
+++ b/sql_engine/query_planner/src/lib.rs
@@ -14,8 +14,8 @@
 
 use catalog::CatalogHandler;
 use data_manipulation_query_plan::{
-    ConstraintValidator, DeleteQueryPlan, DynamicValues, FullTableScan, InsertQueryPlan, QueryPlan, Repeater,
-    SelectQueryPlan, StaticExpressionEval, StaticValues, TableRecordKeys, UpdateQueryPlan,
+    ConstraintValidator, DeleteQueryPlan, DynamicValues, Filter, FullTableScan, InsertQueryPlan, Projection, QueryPlan,
+    Repeater, SelectQueryPlan, StaticExpressionEval, StaticValues, TableRecordKeys, UpdateQueryPlan,
 };
 use data_manipulation_typed_queries::TypedQuery;
 use data_manipulation_typed_tree::{DynamicTypedItem, DynamicTypedTree};
@@ -69,7 +69,7 @@ impl<'p> QueryPlanner<'p> {
             TypedQuery::Select(select) => {
                 let table = self.database.table(&select.full_table_name);
                 QueryPlan::Select(SelectQueryPlan::new(
-                    FullTableScan::new(&table),
+                    Filter::new(Projection::new(FullTableScan::new(&table)), select.filter),
                     select
                         .projection_items
                         .into_iter()

--- a/sql_engine/query_planner/src/lib.rs
+++ b/sql_engine/query_planner/src/lib.rs
@@ -51,7 +51,7 @@ impl<'p> QueryPlanner<'p> {
             TypedQuery::Delete(delete) => {
                 let table = self.database.table(&delete.full_table_name);
                 QueryPlan::Delete(DeleteQueryPlan::new(
-                    TableRecordKeys::new(FullTableScan::new(&table)),
+                    TableRecordKeys::new(Filter::new(Projection::new(FullTableScan::new(&table)), delete.filter)),
                     table,
                 ))
             }

--- a/sql_engine/query_planner/src/lib.rs
+++ b/sql_engine/query_planner/src/lib.rs
@@ -59,7 +59,10 @@ impl<'p> QueryPlanner<'p> {
                 let table = self.database.table(&update.full_table_name);
                 QueryPlan::Update(UpdateQueryPlan::new(
                     ConstraintValidator::new(
-                        DynamicValues::new(Repeater::new(update.assignments), FullTableScan::new(&table)),
+                        DynamicValues::new(
+                            Repeater::new(update.assignments),
+                            Filter::new(Projection::new(FullTableScan::new(&table)), update.filter),
+                        ),
                         self.catalog.columns(&update.full_table_name),
                     ),
                     FullTableScan::new(&table),

--- a/sql_engine/query_processing/type_inference/src/lib.rs
+++ b/sql_engine/query_processing/type_inference/src/lib.rs
@@ -151,7 +151,7 @@ impl TypeInference {
                 }
             }
             StaticUntypedTree::Item(StaticUntypedItem::Const(UntypedValue::Number(num))) => {
-                println!("NUM {:?}", num);
+                log::trace!("NUM {:?}", num);
                 if num.is_integer() {
                     if self.small_int_range.contains(&num) {
                         StaticTypedTree::Item(StaticTypedItem::Const(TypedValue::Num {

--- a/sql_engine/scalar/src/lib.rs
+++ b/sql_engine/scalar/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use types::SqlTypeFamily;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum ScalarValue {
     Num {
         value: BigDecimal,

--- a/storage/in_memory/src/lib.rs
+++ b/storage/in_memory/src/lib.rs
@@ -59,7 +59,7 @@ impl Storage for InMemoryDatabase {
 
     fn lookup_tree<T: Into<String>>(&self, table: T) -> InMemoryTree {
         let table = table.into();
-        println!("LOOKUP {:?}", table);
+        log::trace!("LOOKUP {:?}", table);
         self.trees.get(&table).unwrap().clone()
     }
 

--- a/tests/compatibility/src/test/groovy/io/isomorphicdb/simple/BasicQueryOperationsSpec.groovy
+++ b/tests/compatibility/src/test/groovy/io/isomorphicdb/simple/BasicQueryOperationsSpec.groovy
@@ -89,7 +89,7 @@ class BasicQueryOperationsSpec extends ThreeSmallIntColumnTable {
   def 'insert update{some} select{all}'() {
     given:
       String insertQuery = 'insert into SCHEMA_NAME.TABLE_NAME values (1, 2, 3), (4, 5, 6), (7, 8, 9)'
-      String updateQuery = 'update SCHEMA_NAME.TABLE_NAME set col1 = 10, col2 = 11, col3 = 12 where col1 = 1'
+      String updateQuery = 'update SCHEMA_NAME.TABLE_NAME set col1 = 10, col2 = 11, col3 = 12 where col1 = 2'
     and:
       pg.executeUpdate insertQuery
       db.executeUpdate insertQuery

--- a/tests/compatibility/src/test/groovy/io/isomorphicdb/simple/BasicQueryOperationsSpec.groovy
+++ b/tests/compatibility/src/test/groovy/io/isomorphicdb/simple/BasicQueryOperationsSpec.groovy
@@ -43,6 +43,26 @@ class BasicQueryOperationsSpec extends ThreeSmallIntColumnTable {
       pgSelect == dbSelect
   }
 
+  def 'insert select{some values}'() {
+    given:
+      String insertQuery = 'insert into SCHEMA_NAME.TABLE_NAME values (1, 2, 3), (4, 5, 6), (7, 8, 9)'
+      String selectQuery = 'select col1, col2, col3 from SCHEMA_NAME.TABLE_NAME where col1 > 1'
+
+    when:
+      int pgInserts = pg.executeUpdate insertQuery
+      int dbInserts = db.executeUpdate insertQuery
+    and:
+      List<GroovyRowResult> pgSelect = pg.rows selectQuery
+      List<GroovyRowResult> dbSelect = db.rows selectQuery
+
+    then:
+      println "INSERTED: ${pgInserts.inspect()}"
+      println "SELECTION: ${pgSelect.inspect()}"
+    and:
+      pgInserts == dbInserts
+      pgSelect == dbSelect
+  }
+
   def 'insert update{all} select{all}'() {
     given:
       String insertQuery = 'insert into SCHEMA_NAME.TABLE_NAME values (1, 2, 3), (4, 5, 6), (7, 8, 9)'
@@ -66,10 +86,56 @@ class BasicQueryOperationsSpec extends ThreeSmallIntColumnTable {
       pgSelect == dbSelect
   }
 
+  def 'insert update{some} select{all}'() {
+    given:
+      String insertQuery = 'insert into SCHEMA_NAME.TABLE_NAME values (1, 2, 3), (4, 5, 6), (7, 8, 9)'
+      String updateQuery = 'update SCHEMA_NAME.TABLE_NAME set col1 = 10, col2 = 11, col3 = 12 where col1 = 1'
+    and:
+      pg.executeUpdate insertQuery
+      db.executeUpdate insertQuery
+
+    when:
+      int pgUpdates = pg.executeUpdate updateQuery
+      int dbUpdates = db.executeUpdate updateQuery
+    and:
+      List<GroovyRowResult> pgSelect = pg.rows SELECT_ALL_QUERY
+      List<GroovyRowResult> dbSelect =db.rows SELECT_ALL_QUERY
+
+    then:
+      println "UPDATED: ${pgUpdates.inspect()}"
+      println "SELECTION: ${pgSelect.inspect()}"
+    and:
+      pgUpdates == dbUpdates
+      pgSelect.sort() == dbSelect.sort()
+  }
+
   def 'insert delete{all} select{all}'() {
     given:
       String insertQuery = 'insert into SCHEMA_NAME.TABLE_NAME values (1, 2, 3), (4, 5, 6), (7, 8, 9)'
       String deleteQuery = 'delete from SCHEMA_NAME.TABLE_NAME'
+    and:
+      pg.executeUpdate insertQuery
+      db.executeUpdate insertQuery
+
+    when:
+      int pgDeletes = pg.executeUpdate deleteQuery
+      int dbDeletes = db.executeUpdate deleteQuery
+    and:
+      List<GroovyRowResult> pgSelect = pg.rows SELECT_ALL_QUERY
+      List<GroovyRowResult> dbSelect = db.rows SELECT_ALL_QUERY
+
+    then:
+      println "DELETED: ${pgDeletes.inspect()}"
+      println "SELECTION: ${pgSelect.inspect()}"
+    and:
+      pgDeletes == dbDeletes
+      pgSelect == dbSelect
+  }
+
+  def 'insert delete{some} select{all}'() {
+    given:
+      String insertQuery = 'insert into SCHEMA_NAME.TABLE_NAME values (1, 2, 3), (4, 5, 6), (7, 8, 9)'
+      String deleteQuery = 'delete from SCHEMA_NAME.TABLE_NAME where col1 > 4'
     and:
       pg.executeUpdate insertQuery
       db.executeUpdate insertQuery


### PR DESCRIPTION
No issue to close

![image](https://pbs.twimg.com/media/Ex-jkkJWQAAUyof.jpg)

#### Description
add the simplest support for `where` clause in `select`, `update` and `delete` queries for simple PostgreSQL queries

#### Client output
e.g. for `psql`

```
postgres=> create schema schema_name;
CREATE SCHEMA
postgres=> create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);
CREATE TABLE
postgres=> insert into schema_name.table_name values (1, 2, 3), (4, 5, 6), (7, 8, 9);
INSERT 0 3
postgres=> update schema_name.table_name set col1 = 7 where col1 = 4;
UPDATE 1
postgres=> select * from schema_name.table_name where col1 = 4
postgres-> ;
 col1 | col2 | col3
------+------+------
(0 rows)

postgres=> select * from schema_name.table_name where col1 = 7;
 col1 | col2 | col3
------+------+------
    7 |    5 |    6
    7 |    8 |    9
(2 rows)

postgres=> delete from schema_name.table_name where col2 = 5;
DELETE 1
postgres=> select * from schema_name.table_name where col1 = 7;
 col1 | col2 | col3
------+------+------
    7 |    8 |    9
(1 row)
```

